### PR TITLE
Add missing eth_getFilterLogs JSON RPC api doc

### DIFF
--- a/docs/get-started/json-rpc-commands.mdx
+++ b/docs/get-started/json-rpc-commands.mdx
@@ -435,6 +435,38 @@ curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/js
 
 <JsonRpcTerminal method="eth_getBlockTransactionCountByNumber" params={[]} network="https://rpc-testnet.dogechain.dog"/>
 
+### eth_getFilterLogs
+
+Returns an array of all logs matching a subscribed filter.
+
+---
+
+<h4><i>Parameters:</i></h4>
+
+* <b> QUANTITY </b> - the filter id.
+
+<h4><i>Returns:</i></h4>
+<b> Array </b> - Array of log objects.
+
+*  For filters created with eth_newBlockFilter the return are block hashes (DATA, 32 Bytes), e.g. ["0x3454645634534..."].
+*  For filters created with eth_newPendingTransactionFilter  the return are transaction hashes (DATA, 32 Bytes), e.g. ["0x6345343454645..."].
+*  For filters created with eth_newFilter logs are objects with the following params:
+    * <b> removed: TAG </b> - true when the log was removed, due to a chain reorganization. false if its a valid log.
+    * <b> logIndex: QUANTITY </b> - integer of the log index position in the block. null when its pending log.
+    * <b> transactionIndex: QUANTITY </b> - integer of the transactions index position log was created from. null when its pending log.
+    * <b> transactionHash: DATA, 32 Bytes </b> - hash of the transactions this log was created from. null when its pending log.
+    * <b> blockHash: DATA, 32 Bytes </b> - hash of the block where this log was in.  null when its pending log.
+    * <b> blockNumber: QUANTITY </b> - the block number where this log was in.  null when its pending log.
+    * <b> address: DATA, 20 Bytes </b> - address from which this log originated.
+    * <b> data: DATA </b> - contains one or more 32 Bytes non-indexed arguments of the log.
+    * <b> topics: Array of DATA </b> - Array of 0 to 4 32 Bytes DATA of indexed log arguments. (In solidity: The first topic is the hash of the signature of the event (e.g. Deposit(address,bytes32,uint256)), except you declared the event with the anonymous specifier.)
+
+<h4><i>Example:</i></h4>
+
+````bash
+curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getFilterLogs","params":["0x16"],"id":1}'
+````
+
 ### eth_getLogs
 
 Returns an array of all logs matching a given filter object.


### PR DESCRIPTION
The feature has added in dogechain repo, see this PR:

https://github.com/dogechain-lab/dogechain/pull/83