### PR TITLE
Fix markdown code showing wrong

### DIFF
--- a/docs/get-started/json-rpc-commands.mdx
+++ b/docs/get-started/json-rpc-commands.mdx
@@ -77,9 +77,9 @@ Returns the currently configured chain id, a value used in replay-protected tran
 Run the command and see live results from our testnet.
 
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
+```
 
 <JsonRpcTerminal method="eth_chainId" params={[]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -107,9 +107,9 @@ Returns information about the sync status of the node
 Run the command and see live results from our testnet.
 
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}'
+```
 
 <JsonRpcTerminal method="eth_syncing" params={[]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -152,9 +152,9 @@ Object - A block object, or null when no block was found:
 Run the command and see live results from our testnet.
 
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true],"id":1}'
+```
 
 <JsonRpcTerminal method="eth_getBlockByNumber" params={["latest", true]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -195,9 +195,9 @@ Returns block information by hash.
 
 <h4><i>Example:</i></h4>
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getBlockByHash","params":["0xaafe4e5f40deffde428b353da73740a9666816d5e8db58a2684e548e79a929e0",false],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getBlockByHash","params":["0xaafe4e5f40deffde428b353da73740a9666816d5e8db58a2684e548e79a929e0",false],"id":1}'
+```
 
 <JsonRpcTerminal method="eth_getBlockByHash" params={["0xaafe4e5f40deffde428b353da73740a9666816d5e8db58a2684e548e79a929e0",false]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -220,9 +220,9 @@ None
 Run the command and see live results from our testnet.
 
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+```
 
 <JsonRpcTerminal method="eth_blockNumber" params={[]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -245,9 +245,9 @@ None
 Run the command and see live results from our testnet.
 
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}'
+```
 
 <JsonRpcTerminal method="eth_gasPrice" params={[]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -268,9 +268,9 @@ Returns the balance of the account of the given address.
 
 <h4><i>Example:</i></h4>
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x407d73d8a49eeb85d32cf465507dd71d507100c1", "latest"],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x407d73d8a49eeb85d32cf465507dd71d507100c1", "latest"],"id":1}'
+```
 
 <JsonRpcTerminal method="eth_getBalance" params={["0x407d73d8a49eeb85d32cf465507dd71d507100c1","latest"]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -290,9 +290,9 @@ Creates new message call transaction or a contract creation for signed transacti
 
 <h4><i>Example:</i></h4>
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"],"id":1}'
+```
 
 ### eth_sendTransaction
 
@@ -317,9 +317,9 @@ Creates new message call transaction or a contract creation, if the data field c
 
 <h4><i>Example:</i></h4>
 
-````bash
+```bash
 curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"from": "0xb60e8dd61c5d32be8058bb8eb970870f07233155","to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567","gas": "0x76c0", "gasPrice": "0x9184e72a000", "value": "0x9184e72a", "data": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"}],"id":1}'
-````
+```
 
 ### eth_getTransactionByHash
 
@@ -352,9 +352,9 @@ Returns the information about a transaction requested by transaction hash.
 <h4><i>Example:</i></h4>
 
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["0xf00d6907863242bb3c305babb2abdc34ea2b57e2a5b2b2808ce9bd4777c74f98"],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["0xf00d6907863242bb3c305babb2abdc34ea2b57e2a5b2b2808ce9bd4777c74f98"],"id":1}'
+```
 
 <JsonRpcTerminal method="eth_getTransactionByHash" params={["0xf00d6907863242bb3c305babb2abdc34ea2b57e2a5b2b2808ce9bd4777c74f98"]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -392,9 +392,9 @@ It also returns either :
 
 <h4><i>Example:</i></h4>
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0xf00d6907863242bb3c305babb2abdc34ea2b57e2a5b2b2808ce9bd4777c74f98"],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0xf00d6907863242bb3c305babb2abdc34ea2b57e2a5b2b2808ce9bd4777c74f98"],"id":1}'
+```
 
 <JsonRpcTerminal method="eth_getTransactionByHash" params={["0xf00d6907863242bb3c305babb2abdc34ea2b57e2a5b2b2808ce9bd4777c74f98"]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -415,9 +415,9 @@ Returns the number of transactions sent from an address.
 
 <h4><i>Example:</i></h4>
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getTransactionCount","params":["0xd33ca668f3ff45b6a629a7db19fc6318c47370e8","latest"],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getTransactionCount","params":["0xd33ca668f3ff45b6a629a7db19fc6318c47370e8","latest"],"id":1}'
+```
 
 <JsonRpcTerminal method="eth_getTransactionCount" params={["0xd33ca668f3ff45b6a629a7db19fc6318c47370e8","latest"]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -439,8 +439,8 @@ Returns the number of transactions in a block matching the given block number.
 
 Run the command and see live results from our testnet.
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getBlockTransactionCountByNumber","params":["latest"],"id":1}'
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getBlockTransactionCountByNumber","params":["latest"],"id":1}'
 ```
 
 <JsonRpcTerminal method="eth_getBlockTransactionCountByNumber" params={["latest"]} network="https://rpc-testnet.dogechain.dog"/>
@@ -473,9 +473,9 @@ Returns an array of all logs matching a subscribed filter.
 
 <h4><i>Example:</i></h4>
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getFilterLogs","params":["d525a0e5-89a1-4e6f-b2cd-a668fd251828"],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getFilterLogs","params":["d525a0e5-89a1-4e6f-b2cd-a668fd251828"],"id":1}'
+```
 
 <JsonRpcTerminal method="eth_getFilterLogs" params={["d525a0e5-89a1-4e6f-b2cd-a668fd251828"]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -501,7 +501,7 @@ Returns an array of all logs matching a given filter object.
 <h4><i>Example:</i></h4>
 
 ```bash
-curl  http://127.0.0.1:15002 -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"0x186A0","toBlock":"0x18894","address":"0x0000000000000000000000000000000000001001"}],"id":1}'
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"0x186A0","toBlock":"0x18894","address":"0x0000000000000000000000000000000000001001"}],"id":1}'
 ```
 
 <JsonRpcTerminal method="eth_getLogs" params={[{"fromBlock":"0x186A0","toBlock":"0x18894","address":"0x0000000000000000000000000000000000001001"}]} network="https://rpc-testnet.dogechain.dog"/>
@@ -523,9 +523,9 @@ Returns code at a given address.
 
 <h4><i>Example:</i></h4>
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getCode","params":["0x0000000000000000000000000000000000001001", "latest"],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getCode","params":["0x0000000000000000000000000000000000001001", "latest"],"id":1}'
+```
 
 <JsonRpcTerminal method="eth_getCode" params={["0x0000000000000000000000000000000000001001", "latest"]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -552,9 +552,9 @@ Executes a new message call immediately without creating a transaction on the bl
 
 <h4><i>Example:</i></h4>
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_call","params":[{see above}],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_call","params":[{see above}],"id":1}'
+```
 
 ### eth_getStorageAt
 
@@ -574,9 +574,9 @@ Returns the value from a storage position at a given address.
 
 <h4><i>Example:</i></h4>
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getStorageAt","params":["0x0000000000000000000000000000000000001001", "0x0000000000000000000000000000000000000000000000000000000000000000", "latest"],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getStorageAt","params":["0x0000000000000000000000000000000000001001", "0x0000000000000000000000000000000000000000000000000000000000000000", "latest"],"id":1}'
+```
 
 <JsonRpcTerminal method="eth_getStorageAt" params={["0x0000000000000000000000000000000000001001", "0x0000000000000000000000000000000000000000000000000000000000000000", "latest"]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -606,9 +606,9 @@ Expect that all properties are optional.
 
 <h4><i>Example:</i></h4>
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_estimateGas","params":[{see above}],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_estimateGas","params":[{see above}],"id":1}'
+```
 
 ### eth_newFilter
 
@@ -631,9 +631,9 @@ To check if the state has changed, call eth_getFilterChanges.
 
 <h4><i>Example:</i></h4>
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_newFilter","params":[{"address":"0x0000000000000000000000000000000000001001"}],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_newFilter","params":[{"address":"0x0000000000000000000000000000000000001001"}],"id":1}'
+```
 
 <JsonRpcTerminal method="eth_newFilter" params={[{"address":"0x0000000000000000000000000000000000001001"}]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -656,9 +656,9 @@ None
 
 Run the command and see live results from our testnet.
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_newBlockFilter","params":[],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_newBlockFilter","params":[],"id":1}'
+```
 
 <JsonRpcTerminal method="eth_newBlockFilter" params={[]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -690,9 +690,9 @@ Polling method for a filter, which returns an array of logs that occurred since 
 
 <h4><i>Example:</i></h4>
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getFilterChanges","params":["bc3ae051-e2cc-4a33-a7be-d5919d576d3e"],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_getFilterChanges","params":["bc3ae051-e2cc-4a33-a7be-d5919d576d3e"],"id":1}'
+```
 
 <JsonRpcTerminal method="eth_getFilterChanges" params={["bc3ae051-e2cc-4a33-a7be-d5919d576d3e"]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -713,9 +713,9 @@ Additionally, filters timeout when they aren’t requested with eth_getFilterCha
 
 <h4><i>Example:</i></h4>
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_uninstallFilter","params":["d525a0e5-89a1-4e6f-b2cd-a668fd251828"],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_uninstallFilter","params":["d525a0e5-89a1-4e6f-b2cd-a668fd251828"],"id":1}'
+```
 
 <JsonRpcTerminal method="eth_uninstallFilter" params={["d525a0e5-89a1-4e6f-b2cd-a668fd251828"]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -735,9 +735,9 @@ Subscriptions are cancelled with a regular RPC call with eth_unsubscribe as a me
 
 <h4><i>Example:</i></h4>
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_unsubscribe","params":["0xf0c4373093c02339baa4ea01a6ad4b2a8d942a87"],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_unsubscribe","params":["0xf0c4373093c02339baa4ea01a6ad4b2a8d942a87"],"id":1}'
+```
 
 <JsonRpcTerminal method="eth_unsubscribe" params={["0xf0c4373093c02339baa4ea01a6ad4b2a8d942a87"]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -762,9 +762,9 @@ None
 Run the command and see live results from our testnet.
 
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"net_version","params":[],"id":83}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"net_version","params":[],"id":83}'
+```
 
 <JsonRpcTerminal method="net_version" params={[]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -787,9 +787,9 @@ None
 Run the command and see live results from our testnet.
 
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"net_listening","params":[],"id":83}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"net_listening","params":[],"id":83}'
+```
 
 <JsonRpcTerminal method="net_listening" params={[]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -812,9 +812,9 @@ None
 Run the command and see live results from our testnet.
 
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}'
+```
 
 <JsonRpcTerminal method="net_peerCount" params={[]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -839,9 +839,9 @@ None
 Run the command and see live results from our testnet.
 
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":1}'
+```
 
 <JsonRpcTerminal method="web3_clientVersion" params={[]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -864,9 +864,9 @@ Returns Keccak-256 (not the standardized SHA3-256) of the given data.
 Run the command and see live results from our testnet.
 
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"web3_sha3","params":["0x68656c6c6f20776f726c64"],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"web3_sha3","params":["0x68656c6c6f20776f726c64"],"id":1}'
+```
 
 <JsonRpcTerminal method="web3_sha3" params={["0x68656c6c6f20776f726c64"]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -888,9 +888,9 @@ None
 Run the command and see live results from our testnet.
 
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"txpool_content","params":[],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"txpool_content","params":[],"id":1}'
+```
 
 <JsonRpcTerminal method="txpool_content" params={[]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -910,9 +910,9 @@ None
 Run the command and see live results from our testnet.
 
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"txpool_inspect","params":[],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"txpool_inspect","params":[],"id":1}'
+```
 
 <JsonRpcTerminal method="txpool_inspect" params={[]} network="https://rpc-testnet.dogechain.dog"/>
 
@@ -931,8 +931,8 @@ None
 Run the command and see live results from our testnet.
 
 
-````bash
-curl  https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"txpool_status","params":[],"id":1}'
-````
+```bash
+curl https://rpc-testnet.dogechain.dog -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"txpool_status","params":[],"id":1}'
+```
 
 <JsonRpcTerminal method="txpool_status" params={[]} network="https://rpc-testnet.dogechain.dog"/>


### PR DESCRIPTION
The code snippet showing in `Markdown` syntax was not right.

Use the standard format.