### PR TITLE
update genesis peer identity

### DIFF
--- a/docs/get-started/full-node-deployment.md
+++ b/docs/get-started/full-node-deployment.md
@@ -159,7 +159,7 @@ $ chown -R dogechain:dogechain /etc/dogechain
         "/ip4/13.215.12.187/tcp/1478/p2p/16Uiu2HAmT4Ck1nrsDybwcodGccnFSWfCgLBF7qZsrf6TdfsLBwLh",
         "/ip4/13.250.197.131/tcp/1478/p2p/16Uiu2HAmQ9QxiZ29mrT3N6JM7jRQduuKeXCHEVdcqfJki6K8dqDS",
         "/ip4/18.141.102.151/tcp/1478/p2p/16Uiu2HAmJsVwfwh7rLzGzVcK1CjbmBqzj5sVGXwQeKtLmSP5sXkK",
-        "/ip4/3.144.193.134/tcp/1478/p2p/16Uiu2HAmP2pQiXKrdCwfLbLhfbyN3CosELLVq6CiucXEyipAtb4u",
+        "/ip4/3.144.193.134/tcp/1478/p2p/16Uiu2HAmBiHY3GkvMfN7qpX2VsBSepz9WMqvFN3j3MF1AMdTwXHm",
         "/ip4/3.17.5.141/tcp/1478/p2p/16Uiu2HAm5QD4KHCc8tU4uP2GhBpzqxAQD61FVrLPeqKA3Ecw8ZmP",
         "/ip4/13.59.177.112/tcp/1478/p2p/16Uiu2HAmJKcLRBgpHLpmTdNaaKMCbZ9kv25KNugxVd6Bj3sgDBWT"
     ]


### PR DESCRIPTION
error log:

```
[ERROR] dogechain.network.discovery: Unable to execute bootnode peer discovery, %w:
   EXTRA_VALUE_AT_END=
   | unable to create new discovery client connection, failed to dial 16Uiu2HAmP2pQiXKrdCwfLbLhfbyN3CosELLVq6CiucXEyipAtb4u:
   |   * [/ip4/3.144.193.134/tcp/1478] failed to negotiate security protocol: peer id mismatch: expected 16Uiu2HAmP2pQiXKrdCwfLbLhfbyN3CosELLVq6CiucXEyipAtb4u, but remote key matches 16Uiu2HAmBiHY3GkvMfN7qpX2VsBSepz9WMqvFN3j3MF1AMdTwXHm
```